### PR TITLE
Update automation material

### DIFF
--- a/06_automation/automation_slides.md
+++ b/06_automation/automation_slides.md
@@ -99,9 +99,11 @@ slideOptions:
 
 - [GitHub Actions](https://github.com/features/actions)
 - [GitLab CI/CD](https://docs.gitlab.com/ee/ci/)
+- [Jenkins](https://www.jenkins.io/)
+- [Woodpecker CI](https://woodpecker-ci.org/)
+  (e.g., in [Codeberg](https://docs.codeberg.org/ci/))
 - [Circle CI](https://circleci.com/)
 - [Travis CI](https://www.travis-ci.com/)
-- [Jenkins](https://www.jenkins.io/)
 - ...
 
 ---

--- a/06_automation/automation_slides.md
+++ b/06_automation/automation_slides.md
@@ -108,6 +108,29 @@ slideOptions:
 
 ---
 
+## Other ways to automate: Make
+
+```make
+# Excerpt of a Makefile to build and archive a LaTeX document
+DOCUMENT = main
+JOBNAME  = my-publication
+FLAGS    = -pdf -output-directory=./build/ -jobname=${JOBNAME}
+DATETIME = $(shell date +"%Y-%m-%d_%H-%M-%S")
+
+.PHONY:all archive
+
+all:
+	latexmk ${FLAGS} ${DOCUMENT}.tex
+
+archive:
+	mkdir -p archive/
+	cp build/${JOBNAME}.pdf archive/${JOBNAME}_${DATETIME}.pdf
+```
+
+See also [Snakemake](https://snakemake.github.io/): "A framework for reproducible data analysis"
+
+---
+
 ## Further Reading
 
 - [GitHub Actions documentation](https://docs.github.com/en/actions)

--- a/06_automation/github_actions_demo.md
+++ b/06_automation/github_actions_demo.md
@@ -11,8 +11,8 @@
   vi testing.yml
   ```
 
-- In the first go, we only want to run the `unittest` tests.
-- Edit `testing.yml` to have following content
+- In the first go, we only want to run the `pytest` tests.
+- Edit `testing.yml` to have the following content
 
   ```yaml
   name: Testing workflow
@@ -27,8 +27,10 @@
         - uses: actions/setup-python@v6
           with:
             python-version: '3.10'
-        - name: "Run unittest"
-          run: python -m unittest
+        - name: "Run pytest"
+          run: |
+            python -m pip install pytest
+            python -m pytest
   ```
 
 - `runs-on` does **not** refer to a Docker container, but to a runner tag.
@@ -94,8 +96,10 @@
         - uses: actions/setup-python@v6
           with:
             python-version: '3.10'
-        - name: "Run unittest"
-          run: python -m unittest
+        - name: "Run pytest"
+          run: |
+            python -m pip install pytest
+            python -m pytest
   ```
 
 - We need to run `actions/checkout` in each job

--- a/06_automation/github_actions_demo.md
+++ b/06_automation/github_actions_demo.md
@@ -138,3 +138,36 @@
   ```bash
   act -j test
   ```
+
+## 5. GitLab CI
+
+In GitLab CI, the same workflow (pipeline) would look as follows, in a `.gitlab-ci.yml` file:
+
+```yaml
+stages:
+  - style
+  - build
+  - test
+
+# Image on which to run the pipeline
+image: ajaust/automation-lecture
+
+check_style:
+  stage: style
+  script:
+    - pip install black
+    - black --check .
+
+build_code:
+  stage: build
+  variables:
+    PROJECT_NAME: "Automation Lecture"
+  script:
+    - echo "Building project $PROJECT_NAME"
+
+test_code:
+  stage: test
+  script:
+    - python -m pip install pytest
+    - python -m pytest
+```

--- a/06_automation/github_actions_demo.md
+++ b/06_automation/github_actions_demo.md
@@ -23,10 +23,10 @@
     test:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/setup-python@v2
+        - uses: actions/checkout@v6
+        - uses: actions/setup-python@v6
           with:
-            python-version: '3.8.10'
+            python-version: '3.10'
         - name: "Run unittest"
           run: python -m unittest
   ```
@@ -70,10 +70,10 @@
     style:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/setup-python@v2
+        - uses: actions/checkout@v6
+        - uses: actions/setup-python@v6
           with:
-            python-version: '3.8.10'
+            python-version: '3.10'
         - name: "Install style checker"
           run: pip install black
         - name: "Run style check"
@@ -87,33 +87,32 @@
         - name: "Run build phase"
           run: echo "Building project $PROJECT_NAME"
     test:
-      needs: build
+      # needs: build
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/setup-python@v2
+        - uses: actions/checkout@v6
+        - uses: actions/setup-python@v6
           with:
-            python-version: '3.8.10'
+            python-version: '3.10'
         - name: "Run unittest"
           run: python -m unittest
   ```
 
-- We need to run `actions/checkout@v2` in each job
+- We need to run `actions/checkout` in each job
     - We could share the repository between jobs via artifacts, but that is uncommon.
-- We need to run `actions/setup-python@v2` since jobs do not share the environment.
+- We need to run `actions/setup-python` since jobs do not share the environment.
 - We specify dependencies by `needs` such that the steps run after each other.
 - We do not have a real build step since it is Python. However, this might be interesting for compiled code.
 
 ## 3. Other Workflows
 
 - Show workflows of [preCICE](https://github.com/precice/precice)
-  - Show `Actions` tab
-    - `Build and test` job, click on a run
-    - Jobs created through test matrix
-    - Click on a job, click on a few steps
-  - Show `workflows` folder, click on `Build and Test`
-  - Only one job. `build`, `test`, ... are modeled as steps
-- If time allows, quickly show DuMuX CI (and explain that GitLab CI works differently)
+    - Show `Actions` tab
+        - `Build and test` job, click on a run
+        - Jobs created through test matrix
+        - Click on a job, click on a few steps
+    - Show `workflows` folder, click on `Build and Test`
+    - Only one job. `build`, `test`, ... are modeled as steps
 
 ## 4. act Demo
 

--- a/06_automation/github_actions_exercise.md
+++ b/06_automation/github_actions_exercise.md
@@ -4,10 +4,9 @@ In this exercise, we create automated workflows and pipelines based on GitHub Ac
 
 ## Preparations
 
-- Create a new repository named "rse102-github-actions-exercise" in your own account/namespace on GitHub (with an empty README file) and clone the repository afterwards.
-  - **Note**: We cannot work with forks here because GitHub Actions may not work in pull requests without explicit approval of the owner of the target repository. It is also easier to add badges (see below) to the `README.md` if the repository is under your control.
-- Add the contents of the [automation exercise repository](https://github.com/RSE-102/automation-exercise) to your own repository. You can do this by copying the files into your own repository, adding, and committing them to Git. Afterwards push the changes to GitHub and verify that your repository contains the same files as the `automation-exercise` repository.
-  - **Note**: If you use another way of adding the data to your repository, e.g., by defining a new remote, make sure that the `origin` remote points to your own repository.
+Import (not fork) the [automation exercise repository](https://github.com/RSE-102/automation-exercise) into your own account/namespace on GitHub.
+
+**Note**: We cannot work with forks here because GitHub Actions may not work in pull requests without explicit approval of the owner of the target repository. It is also easier to add badges (see below) to the `README.md` if the repository is under your control.
 
 ## Task descriptions
 

--- a/06_automation/github_actions_slides.md
+++ b/06_automation/github_actions_slides.md
@@ -78,7 +78,7 @@ From [GitHub Actions tutorial](https://docs.github.com/en/actions)
 
 ## Setting up a Workflow
 
-- Workflow file files stored `${REPO_ROOT}/.github/workflows`
+- Workflow files stored in `${REPO_ROOT}/.github/workflows`
 - Configured via YAML file
 
 ```yaml
@@ -203,13 +203,14 @@ steps:
       name: my-artifact
       path: my_file.txt
       retention-days: 5
+      include-hidden-files: true # Necessary if upload contains hidden file.
   ```
 
 - Downloading artifact
 
   ```yaml
   - name: "Download a single artifact"
-    uses: actions/download-artifact@v2
+    uses: actions/download-artifact@v4
     with:
       name: my-artifact
   ```
@@ -263,3 +264,4 @@ steps:
 
 - [GitHub Actions documentation](https://docs.github.com/en/actions)
 - [GitHub Actions quickstart](https://docs.github.com/en/actions/quickstart)
+- [Multi-project CI/CD](https://multiprojectdevops.github.io/tutorials/)


### PR DESCRIPTION
This PR:

- Synchronizes the automation material with the SSE lecture material
- Updates the GitHub Actions demo to use pytest instead of unittest, based on the latest changes in the Python Testing exercise
- Adds an example for GitLab CI (we had none in RSE-102 before)
- Adds a slide about Make in the automation lecture, and a link to Snakemake